### PR TITLE
Bug: function index definition are not right

### DIFF
--- a/src/main/java/com/chetanmeh/oak/index/config/IndexDefinitionBuilder.java
+++ b/src/main/java/com/chetanmeh/oak/index/config/IndexDefinitionBuilder.java
@@ -92,6 +92,16 @@ public class IndexDefinitionBuilder {
             return propRule;
         }
 
+        public PropertyRule function(String functionkey, String functionValue){
+            PropertyRule propRule = props.get(functionkey);
+            if (propRule == null){
+                propRule = new PropertyRule(this, createChild(propertiesBuilder, createPropNodeName(functionkey)),
+                        functionValue, "function");
+                props.put(functionkey, propRule);
+            }
+            return propRule;
+        }
+
         private String createPropNodeName(String name) {
             name = getSafePropName(name);
             if (name.isEmpty()){
@@ -113,10 +123,29 @@ public class IndexDefinitionBuilder {
         private final IndexRule indexRule;
         private final NodeBuilder builder;
 
+        /**
+         *
+         * @param indexRule
+         * @param builder
+         * @param name name is the property which need to be indexed. The key for this property is fixed to "name".
+         */
         private PropertyRule(IndexRule indexRule, NodeBuilder builder, String name) {
             this.indexRule = indexRule;
             this.builder = builder;
             builder.setProperty(LuceneIndexConstants.PROP_NAME, name);
+        }
+
+        /**
+         *
+         * @param indexRule
+         * @param builder
+         * @param name name is the property which need to be indexed.
+         * @param nameKey nameKey is the key used in indexdefinition property.
+         */
+        private PropertyRule(IndexRule indexRule, NodeBuilder builder, String name, String nameKey) {
+            this.indexRule = indexRule;
+            this.builder = builder;
+            builder.setProperty(nameKey, name);
         }
 
         public PropertyRule useInExcerpt(){

--- a/src/test/groovy/com/chetanmeh/oak/index/config/generator/IndexConfigGeneratorHelperTest.groovy
+++ b/src/test/groovy/com/chetanmeh/oak/index/config/generator/IndexConfigGeneratorHelperTest.groovy
@@ -16,6 +16,14 @@ select * from [nt:base] where foo = 'bar\'
     }
 
     @Test
+    public void functionQuery() throws Exception {
+        dumpIndex('''#Paste your queries here
+
+ select * from[dam:Asset] as a where lower(upper(length([jcr:content/mytest])))="mytest" and isdescendantnode(a, \'/content\')
+''')
+    }
+
+    @Test
     public void multipleQueries() throws Exception{
         dumpIndex('''SELECT
   *


### PR DESCRIPTION
For query 
`AND ((LOWER([selector_1].[name]) = 'noa_6412_bodytxt_en')`
Creates:
`"functionlowername": {
                    "name": "function*lower*@name",
                    "propertyIndex": true,
                    "jcr:primaryType": "nt:unstructured"
                },
                "name": {
                    "name": "name",
                    "propertyIndex": true,
                    "jcr:primaryType": "nt:unstructured",
                    "notNullCheckEnabled": true
                }
`

Instead of:
`"functionlowername": {
                    "function": "fn:lower-case(@name)",
                    "propertyIndex": true,
                    "jcr:primaryType": "nt:unstructured"
                },
`
